### PR TITLE
meson.build: interpret x86 as i686

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,10 @@
 project('freestnd-cxx-hdrs')
 
-incl = include_directories(host_machine.cpu_family() / 'include')
+cpu = host_machine.cpu_family()
+if cpu == 'x86'
+  cpu = 'i686'
+endif
+
+incl = include_directories(cpu / 'include')
 
 freestnd_cxx_hdrs_dep = declare_dependency(include_directories: incl)


### PR DESCRIPTION
Meson's host_machine.cpu_family() calls i686 systems 'x86'.