### PR TITLE
update gcc to 16.1.0

### DIFF
--- a/make_toolchain.sh
+++ b/make_toolchain.sh
@@ -15,11 +15,11 @@ if [ -z "$TARGET" ]; then
 fi
 
 if [ -z "$BINUTILSVERSION" ]; then
-    BINUTILSVERSION=2.45
+    BINUTILSVERSION=2.46.0
 fi
 
 if [ -z "$GCCVERSION" ]; then
-    GCCVERSION=14.3.0
+    GCCVERSION=16.1.0
 fi
 
 if command -v gmake; then
@@ -57,11 +57,11 @@ export PATH="$PREFIX/bin:$PATH"
 
 if [ ! -f binutils-$BINUTILSVERSION.tar.xz ]; then
     curl -Lo binutils-$BINUTILSVERSION.tar.xz https://ftpmirror.gnu.org/gnu/binutils/binutils-$BINUTILSVERSION.tar.xz
-    b2sum binutils-$BINUTILSVERSION.tar.xz | grep -q 1ce72346b1f531c89feb86b407e2c649151b506ffbd1a02d413411d36f7ede98fa9a1adf75dd941c01df5fe7e6bf151828b269eeb7c278315ca8004bff22eb7f
+    b2sum binutils-$BINUTILSVERSION.tar.xz | grep -q 9f4fd8897d237eb5003bdf439537dfc5f8c681e9ff939fb06bb8235ed298031ea4cc91611edb640ffc432199d5791289d003fe0d07acce80327dc40595a5eb9e
 fi
 if [ ! -f gcc-$GCCVERSION.tar.xz ]; then
     curl -Lo gcc-$GCCVERSION.tar.xz https://ftpmirror.gnu.org/gnu/gcc/gcc-$GCCVERSION/gcc-$GCCVERSION.tar.xz
-    b2sum gcc-$GCCVERSION.tar.xz | grep -q 11c0e549b2e9b4bbbe4cd64782032d2ec783b3db8d4aa538ebd0a0c9760d8e521c32007891a608b081bc6dd353d4eb23030c5e2b9fe9a20c4894a8455dde47b6
+    b2sum gcc-$GCCVERSION.tar.xz | grep -q ceb07866b6b17eb4c69a6b51241b275bc5ec506603a7c1a4c1e2585091a09fc647be945beeff76700bffd9018bda81b072d84f909fd7998baa0cfe3f0eb550b4
 fi
 
 rm -rf build

--- a/patches/bitset.patch
+++ b/patches/bitset.patch
@@ -1,0 +1,25 @@
+--- include/bits/stdexcept_throwfwd.h	2026-05-29 21:22:11.878079768 +0400
++++ include-patched/bits/stdexcept_throwfwd.h	2026-05-30 00:22:44.222941017 +0400
+@@ -117,6 +117,22 @@
+   __throw_overflow_error(const char*)
+   { std::__terminate(); }
+ 
++  __attribute__((__noreturn__)) inline void
++  __throw_logic_error(const char*)
++  { std::__terminate(); }
++
++  __attribute__((__noreturn__)) inline void
++  __throw_domain_error(const char*)
++  { std::__terminate(); }
++
++  __attribute__((__noreturn__)) inline void
++  __throw_length_error(const char*)
++  { std::__terminate(); }
++
++  __attribute__((__noreturn__)) inline void
++  __throw_underflow_error(const char*)
++  { std::__terminate(); }
++
+ #endif // HOSTED
+ 
+ _GLIBCXX_END_NAMESPACE_VERSION

--- a/patches/clang-compat.patch
+++ b/patches/clang-compat.patch
@@ -1,7 +1,6 @@
-diff '--color=auto' -urN include/atomic include-patched/atomic
---- include/atomic	2024-09-22 05:50:48.546122362 +0200
-+++ include-patched/atomic	2024-09-22 05:59:15.115746337 +0200
-@@ -1650,6 +1650,7 @@
+--- include/atomic	2026-05-29 21:22:12.001085501 +0400
++++ include-patched/atomic	2026-05-30 00:22:44.150936961 +0400
+@@ -1743,6 +1743,7 @@
        using __atomic_float<double>::operator=;
      };
  
@@ -9,7 +8,7 @@ diff '--color=auto' -urN include/atomic include-patched/atomic
    template<>
      struct atomic<long double> : __atomic_float<long double>
      {
-@@ -1664,6 +1665,7 @@
+@@ -1757,6 +1758,7 @@
  
        using __atomic_float<long double>::operator=;
      };
@@ -17,24 +16,9 @@ diff '--color=auto' -urN include/atomic include-patched/atomic
  
  #ifdef __STDCPP_FLOAT16_T__
    template<>
-diff '--color=auto' -urN include/bits/stl_algobase.h include-patched/bits/stl_algobase.h
---- include/bits/stl_algobase.h	2024-09-22 05:50:48.546122362 +0200
-+++ include-patched/bits/stl_algobase.h	2024-09-22 05:58:04.080067281 +0200
-@@ -1072,8 +1072,10 @@
-   __size_to_integer(float __n) { return (long long)__n; }
-   inline _GLIBCXX_CONSTEXPR long long
-   __size_to_integer(double __n) { return (long long)__n; }
-+#if !(defined(__clang__) && !__STDC_HOSTED__) // clang in kernel context
-   inline _GLIBCXX_CONSTEXPR long long
-   __size_to_integer(long double __n) { return (long long)__n; }
-+#endif
- #if !defined(__STRICT_ANSI__) && defined(_GLIBCXX_USE_FLOAT128)
-   __extension__ inline _GLIBCXX_CONSTEXPR long long
-   __size_to_integer(__float128 __n) { return (long long)__n; }
-diff '--color=auto' -urN include/limits include-patched/limits
---- include/limits	2024-09-23 19:17:13.246614553 +0200
-+++ include-patched/limits	2024-09-23 19:21:05.459515170 +0200
-@@ -113,6 +113,8 @@
+--- include/limits	2026-05-29 21:22:12.042087411 +0400
++++ include-patched/limits	2026-05-30 00:22:44.152514560 +0400
+@@ -120,6 +120,8 @@
  
  // Default values.  Should be overridden in configuration files if necessary.
  
@@ -43,7 +27,7 @@ diff '--color=auto' -urN include/limits include-patched/limits
  #ifndef __glibcxx_long_double_has_denorm_loss
  #  define __glibcxx_long_double_has_denorm_loss false
  #endif
-@@ -123,6 +125,8 @@
+@@ -130,6 +132,8 @@
  #  define __glibcxx_long_double_tinyness_before false
  #endif
  
@@ -52,7 +36,7 @@ diff '--color=auto' -urN include/limits include-patched/limits
  // You should not need to define any macros below this point.
  
  #define __glibcxx_signed_b(T,B)	((T)(-1) < 0)
-@@ -1815,6 +1819,8 @@
+@@ -1821,6 +1825,8 @@
  #undef __glibcxx_double_traps
  #undef __glibcxx_double_tinyness_before
  
@@ -61,7 +45,7 @@ diff '--color=auto' -urN include/limits include-patched/limits
    /// numeric_limits<long double> specialization.
    template<>
      struct numeric_limits<long double>
-@@ -1890,6 +1896,8 @@
+@@ -1896,6 +1902,8 @@
  #undef __glibcxx_long_double_traps
  #undef __glibcxx_long_double_tinyness_before
  
@@ -70,3 +54,16 @@ diff '--color=auto' -urN include/limits include-patched/limits
  #define __glibcxx_concat3_(P,M,S) P ## M ## S
  #define __glibcxx_concat3(P,M,S) __glibcxx_concat3_ (P,M,S)
  
+--- include/bits/stl_algobase.h	2026-05-29 21:22:11.887080188 +0400
++++ include-patched/bits/stl_algobase.h	2026-05-30 00:22:44.167508764 +0400
+@@ -1060,8 +1060,10 @@
+   __size_to_integer(float __n) { return (long long)__n; }
+   inline _GLIBCXX_CONSTEXPR long long
+   __size_to_integer(double __n) { return (long long)__n; }
++#if !(defined(__clang__) && !__STDC_HOSTED__) // clang in kernel context
+   inline _GLIBCXX_CONSTEXPR long long
+   __size_to_integer(long double __n) { return (long long)__n; }
++#endif
+ #ifdef _GLIBCXX_USE_FLOAT128
+   __extension__ inline _GLIBCXX_CONSTEXPR long long
+   __size_to_integer(__float128 __n) { return (long long)__n; }

--- a/patches/generator.patch
+++ b/patches/generator.patch
@@ -1,0 +1,16 @@
+--- include/generator	2026-05-29 21:22:12.034087039 +0400
++++ include-patched/generator	2026-05-30 00:35:40.430516972 +0400
+@@ -45,10 +45,13 @@
+ #include <bits/ranges_util.h>
+ #include <bits/elements_of.h>
+ #include <bits/uses_allocator.h>
++#include <bits/alloc_traits.h> // __alloc_rebind (freestanding)
+ #include <bits/exception_ptr.h>
+ #include <cstddef>
+ #include <cstdint>
++#if _GLIBCXX_HOSTED
+ #include <cstring>
++#endif
+ #include <coroutine>
+ 
+ #include <type_traits>

--- a/toolchain-patches/gcc/libstdcxx-install-binders.patch
+++ b/toolchain-patches/gcc/libstdcxx-install-binders.patch
@@ -1,0 +1,38 @@
+diff -urN a/libstdc++-v3/include/Makefile.am b/libstdc++-v3/include/Makefile.am
+--- a/libstdc++-v3/include/Makefile.am	2026-04-30 12:33:29.000000000 +0400
++++ b/libstdc++-v3/include/Makefile.am	2026-05-30 00:30:47.666666919 +0400
+@@ -128,6 +128,7 @@
+ 	${bits_srcdir}/allocator.h \
+ 	${bits_srcdir}/alloc_traits.h \
+ 	${bits_srcdir}/atomic_base.h \
++	${bits_srcdir}/binders.h \
+ 	${bits_srcdir}/c++0x_warning.h \
+ 	${bits_srcdir}/boost_concept_check.h \
+ 	${bits_srcdir}/concept_check.h \
+@@ -201,7 +202,6 @@
+ 	${bits_srcdir}/basic_ios.tcc \
+ 	${bits_srcdir}/basic_string.h \
+ 	${bits_srcdir}/basic_string.tcc \
+-	${bits_srcdir}/binders.h \
+ 	${bits_srcdir}/charconv.h \
+ 	${bits_srcdir}/chrono.h \
+ 	${bits_srcdir}/chrono_io.h \
+diff -urN a/libstdc++-v3/include/Makefile.in b/libstdc++-v3/include/Makefile.in
+--- a/libstdc++-v3/include/Makefile.in	2026-04-30 12:33:29.000000000 +0400
++++ b/libstdc++-v3/include/Makefile.in	2026-05-30 00:30:47.647290964 +0400
+@@ -486,6 +486,7 @@
+ 	${bits_srcdir}/allocator.h \
+ 	${bits_srcdir}/alloc_traits.h \
+ 	${bits_srcdir}/atomic_base.h \
++	${bits_srcdir}/binders.h \
+ 	${bits_srcdir}/c++0x_warning.h \
+ 	${bits_srcdir}/boost_concept_check.h \
+ 	${bits_srcdir}/concept_check.h \
+@@ -557,7 +558,6 @@
+ @GLIBCXX_HOSTED_TRUE@	${bits_srcdir}/basic_ios.tcc \
+ @GLIBCXX_HOSTED_TRUE@	${bits_srcdir}/basic_string.h \
+ @GLIBCXX_HOSTED_TRUE@	${bits_srcdir}/basic_string.tcc \
+-@GLIBCXX_HOSTED_TRUE@	${bits_srcdir}/binders.h \
+ @GLIBCXX_HOSTED_TRUE@	${bits_srcdir}/charconv.h \
+ @GLIBCXX_HOSTED_TRUE@	${bits_srcdir}/chrono.h \
+ @GLIBCXX_HOSTED_TRUE@	${bits_srcdir}/chrono_io.h \


### PR DESCRIPTION
tested the headers with gcc 14-16, clang 19-22 with following flags:
```
-target x86_64-elf (only on clang of course)
-std=c++2b (23)
-ffreestanding -nostdinc -nostdinc++
-fno-exceptions -fno-rtti
-mno-sse -mno-sse2 -mno-mmx -mno-80387
-mno-red-zone
```